### PR TITLE
Bug fixes and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ YAML is a superset of JSON and, as such, is a convenient format for specifying h
 config["my-app-name"]
 ```
 
+⚠️ Although Javascript and YAML are case sensitive and accept properties with same name but different case in the same object (e.g. `variable`/`VARiable`, this lib will through an error in such cases. This constraint has the goal to improve the configuration readability and to make it possible the override of such properties by system variables.
+
 #### Name Convention
 
 Each configuration file in `auto-config-js` is called a profile configuration. Because of that, configuration files are named using the following convention:

--- a/lib/autoConfig.js
+++ b/lib/autoConfig.js
@@ -2,68 +2,12 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-function isObject(item) {
-  return item && typeof item === 'object' && !Array.isArray(item);
-}
-
-/**
- * Check if the reference value is defined and has a value
- * @param obj
- * @returns {boolean|boolean}
- */
-function hasValue(obj) {
-  return obj !== null && obj !== undefined;
-}
-
-/**
- * Get the property from a object ignoring case
- * E.g.: obj.getProperty('HeLo') === obj.getProperty('hElO')
- */
-function getProperty(object, key) {
-  return object[
-    Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase())
-  ];
-}
-
-/**
- * Set the value for an EXISTING property. It finds the property ignoring the case. If the following operations
- * run in sequence the second will override the value of the first:
- * obj.setProperty('HeLo', 'hi')
- * obj.setProperty('hElO', 'hello')
- *
- * It also casts the new value to have the same data type. If cast fails the operation also fails
- */
-function setProperty(object, key, systemVariable) {
-  const objectKey = Object.keys(object).find(
-    k => k.toLowerCase() === key.toLowerCase()
-  );
-  const value = process.env[systemVariable];
-  // const castedValue = cast(object[objectKey], value);
-
-  switch (typeof object[objectKey]) {
-    case 'boolean':
-      if (value.toLowerCase() !== 'true' && value.toLowerCase() !== 'false') {
-        throw new Error(
-          `${systemVariable} contains invalid data. true/false expected.`
-        );
-      }
-      // eslint-disable-next-line no-param-reassign
-      object[objectKey] = value.toLowerCase() === 'true';
-      break;
-    case 'number':
-      if (!Number(value)) {
-        throw new Error(
-          `${systemVariable} contains invalid data. Number expected.`
-        );
-      }
-      // eslint-disable-next-line no-param-reassign
-      object[objectKey] = Number(value);
-      break;
-    default:
-      // eslint-disable-next-line no-param-reassign
-      object[objectKey] = value;
-  }
-}
+const {
+  isObject,
+  hasValue,
+  getPropertyCaseInsensitive,
+  setPropertyCaseInsensitive,
+} = require('./utils');
 
 // Configuration object shared in the whole application
 let config;
@@ -113,22 +57,33 @@ function findPropertyToBeOverride(configObj, tokens) {
 
   // Cases
   // The root path is already the sysvar name
-  if (hasValue(getProperty(configObj, tokens.join('')))) {
+  if (hasValue(getPropertyCaseInsensitive(configObj, tokens.join('')))) {
     return { node: configObj, key: tokens.join('') };
   }
 
   // End of the path, the property is there and there is no one else to check
-  if (hasValue(getProperty(configObj, current)) && !hasValue(next)) {
+  if (
+    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
+    !hasValue(next)
+  ) {
     return { node: configObj, key: current };
   }
 
   // Start/middle of the path. Has the property and the next, keep calling
   if (
-    hasValue(getProperty(configObj, current)) &&
-    hasValue(getProperty(getProperty(configObj, current), next))
+    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
+    hasValue(
+      getPropertyCaseInsensitive(
+        getPropertyCaseInsensitive(configObj, current),
+        next
+      )
+    )
   ) {
     const [, ...rest] = tokens;
-    return findPropertyToBeOverride(getProperty(configObj, current), rest);
+    return findPropertyToBeOverride(
+      getPropertyCaseInsensitive(configObj, current),
+      rest
+    );
   }
 
   // Find the property in this level but not in the next
@@ -136,11 +91,16 @@ function findPropertyToBeOverride(configObj, tokens) {
   // if it is the next
   // Covers: cookie.maxAge <-> COOKIE_MAX_AGE
   if (
-    hasValue(getProperty(configObj, current)) &&
-    !hasValue(getProperty(getProperty(configObj, current), next))
+    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
+    !hasValue(
+      getPropertyCaseInsensitive(
+        getPropertyCaseInsensitive(configObj, current),
+        next
+      )
+    )
   ) {
     const [, ...rest] = tokens;
-    if (hasValue(getProperty(configObj, rest.join('')))) {
+    if (hasValue(getPropertyCaseInsensitive(configObj, rest.join('')))) {
       return { node: configObj, key: tokens.join('') };
     }
     return undefined;
@@ -164,7 +124,7 @@ function overrideConfigValuesFromSystemVariables(configObj) {
 
     const result = findPropertyToBeOverride(configObj, tokens);
     if (result && result.node && result.key) {
-      setProperty(result.node, result.key, systemVariable);
+      setPropertyCaseInsensitive(result.node, result.key, systemVariable);
     }
   });
 }

--- a/lib/autoConfig.js
+++ b/lib/autoConfig.js
@@ -4,12 +4,10 @@ const yaml = require('js-yaml');
 
 const {
   isObject,
-  hasValue,
-  getPropertyCaseInsensitive,
-  setPropertyCaseInsensitive,
+  overrideConfigValuesFromSystemVariables,
 } = require('./utils');
 
-// Configuration object shared in the whole application
+// Global config
 let config;
 
 /**
@@ -30,103 +28,6 @@ function mergeDeep(target, source) {
     });
   }
   return output;
-}
-
-/**
- * Receives a list of tokens and try to find a property that need to be updated (if it exists in the config).
- * This operation returns the object that will receive the update. For example:
- *
- * System variable: MY_CUSTOM_SYS_VAR
- * Tokens:  [my, custom, sys, var]
- *
- * Return the object if config contains any of the following (match for the system var):
- * my.custom.sys.var
- * my.custom.sysVar
- * my.customSysVar
- * myCustomSysVar
- *
- * The following are not valid:
- * myCustom.sys.var
- *
- * Only the ending can have camel case names
- *
- * @return {node: *, key: *} the node (object) that will be updated
- */
-function findPropertyToBeOverride(configObj, tokens) {
-  const [current, next] = tokens;
-
-  // Cases
-  // The root path is already the sysvar name
-  if (hasValue(getPropertyCaseInsensitive(configObj, tokens.join('')))) {
-    return { node: configObj, key: tokens.join('') };
-  }
-
-  // End of the path, the property is there and there is no one else to check
-  if (
-    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
-    !hasValue(next)
-  ) {
-    return { node: configObj, key: current };
-  }
-
-  // Start/middle of the path. Has the property and the next, keep calling
-  if (
-    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
-    hasValue(
-      getPropertyCaseInsensitive(
-        getPropertyCaseInsensitive(configObj, current),
-        next
-      )
-    )
-  ) {
-    const [, ...rest] = tokens;
-    return findPropertyToBeOverride(
-      getPropertyCaseInsensitive(configObj, current),
-      rest
-    );
-  }
-
-  // Find the property in this level but not in the next
-  // Then try by concatenating the remaining tokens and comparing
-  // if it is the next
-  // Covers: cookie.maxAge <-> COOKIE_MAX_AGE
-  if (
-    hasValue(getPropertyCaseInsensitive(configObj, current)) &&
-    !hasValue(
-      getPropertyCaseInsensitive(
-        getPropertyCaseInsensitive(configObj, current),
-        next
-      )
-    )
-  ) {
-    const [, ...rest] = tokens;
-    if (hasValue(getPropertyCaseInsensitive(configObj, rest.join('')))) {
-      return { node: configObj, key: tokens.join('') };
-    }
-    return undefined;
-  }
-  // If does not fit any of the previous
-  return undefined;
-}
-
-/**
- * This function reads the system variables and try to match the sysvar with some local property. For example,
- * we can have the sysvar PLEASE_DO.NOT_HATE_ME. This can resolve to please.do.not.hateMe or please.doNotHateMe.
- * To do this the function breaks the sysvar in tokens and try to find the combination groups. It only updates existing
- * properties. No new properties are created. The grouping match is only valid to the suffixes, for example, the first
- * is valid but the second is not:
- * please.do.not.hateMe
- * pleaseDoNot.hate.me
- */
-function overrideConfigValuesFromSystemVariables(configObj) {
-  Object.keys(process.env).forEach(systemVariable => {
-    const tokens = systemVariable.toLowerCase().split('_');
-
-    const result = findPropertyToBeOverride(configObj, tokens);
-    if (result && result.node && result.key) {
-      setPropertyCaseInsensitive(result.node, result.key, systemVariable);
-    }
-  });
 }
 
 /**
@@ -164,7 +65,7 @@ function init({ profile = process.env.NODE_ENV, configDirectory = './' }) {
   try {
     // Load config
     const filePath = path.join(configDirectory, `app.${profile}.config.yaml`);
-    console.log(filePath);
+
     const confObj = yaml.safeLoad(fs.readFileSync(filePath, 'utf8'));
     config = loadConfig(confObj, filePath, configDirectory);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,9 +56,34 @@ function setPropertyCaseInsensitive(object, key, systemVariable) {
   }
 }
 
+function overrideConfigValuesFromSystemVariables(
+  configObj,
+  systemVariables = Object.keys(process.env)
+) {
+  systemVariables.forEach(sysVar => {
+    let tokens = sysVar.toLowerCase().split('_');
+
+    let currentObj = configObj;
+    let currentProp = tokens.shift();
+    while (tokens.length) {
+      const propValue = getPropertyCaseInsensitive(currentObj, currentProp);
+      if (propValue) {
+        currentObj = propValue;
+        currentProp = tokens.shift();
+      } else {
+        tokens = [];
+      }
+    }
+    if (currentObj && currentProp && currentObj[currentProp]) {
+      setPropertyCaseInsensitive(currentObj, currentProp, sysVar);
+    }
+  });
+}
+
 module.exports = {
   isObject,
   hasValue,
   getPropertyCaseInsensitive,
   setPropertyCaseInsensitive,
+  overrideConfigValuesFromSystemVariables,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@ function getPropertyNameCaseInsensitive(object, property) {
     k => k.toLowerCase() === property.toLowerCase()
   );
   if (objKeys.length > 1) {
-    throw new Error(`Duplicated property found: ${property}`);
+    throw new Error(`Found duplicated {${property}} property`);
   }
   return objKeys[0];
 }
@@ -31,18 +31,24 @@ function getPropertyCaseInsensitive(object, property) {
 function setPropertyCaseInsensitive(object, property, value) {
   const propName = getPropertyNameCaseInsensitive(object, property);
 
+  if (!propName) {
+    throw new Error(
+      `Error trying to set value {${value}} for non-existing property {${property}}`
+    );
+  }
+
   switch (typeof object[propName]) {
     case 'boolean':
       if (value.toLowerCase() !== 'true' && value.toLowerCase() !== 'false') {
         throw new Error(
-          `true/false value expected for property {${propName}}, got {${value}}`
+          `Value true/false expected for property {${propName}}, got {${value}}`
         );
       }
       // eslint-disable-next-line no-param-reassign
       object[propName] = value.toLowerCase() === 'true';
       break;
     case 'number':
-      if (!Number(value)) {
+      if (Number.isNaN(Number(value))) {
         throw new Error(
           `Number expected for property {${propName}}, got {${value}}`
         );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,23 +2,18 @@ function isObject(item) {
   return item && typeof item === 'object' && !Array.isArray(item);
 }
 
-/**
- * Check if the reference value is defined and has a value
- * @param obj
- * @returns {boolean|boolean}
- */
 function hasValue(obj) {
   return obj !== null && obj !== undefined;
 }
 
-/**
- * Get the property from a object ignoring case.
- * E.g.: obj.getProperty('HeLo') === obj.getProperty('hElO')
- */
 function getPropertyCaseInsensitive(object, key) {
-  return object[
-    Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase())
-  ];
+  const objKeys = Object.keys(object).filter(
+    k => k.toLowerCase() === key.toLowerCase()
+  );
+  if (objKeys.length > 1) {
+    throw new Error(`Duplicated property found: ${key}`);
+  }
+  return object[objKeys];
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,14 +6,18 @@ function hasValue(obj) {
   return obj !== null && obj !== undefined;
 }
 
-function getPropertyCaseInsensitive(object, key) {
+function getPropertyNameCaseInsensitive(object, property) {
   const objKeys = Object.keys(object).filter(
-    k => k.toLowerCase() === key.toLowerCase()
+    k => k.toLowerCase() === property.toLowerCase()
   );
   if (objKeys.length > 1) {
-    throw new Error(`Duplicated property found: ${key}`);
+    throw new Error(`Duplicated property found: ${property}`);
   }
-  return isObject(object[objKeys[0]]) ? object[objKeys[0]] : undefined;
+  return objKeys[0];
+}
+
+function getPropertyCaseInsensitive(object, property) {
+  return object[getPropertyNameCaseInsensitive(object, property)];
 }
 
 /**
@@ -24,58 +28,55 @@ function getPropertyCaseInsensitive(object, key) {
  *
  * It also casts the new value to have the same data type. If cast fails the operation also fails
  */
-function setPropertyCaseInsensitive(object, key, systemVariable) {
-  const objectKey = Object.keys(object).find(
-    k => k.toLowerCase() === key.toLowerCase()
-  );
-  const value = process.env[systemVariable];
-  // const castedValue = cast(object[objectKey], value);
+function setPropertyCaseInsensitive(object, property, value) {
+  const propName = getPropertyNameCaseInsensitive(object, property);
 
-  switch (typeof object[objectKey]) {
+  switch (typeof object[propName]) {
     case 'boolean':
       if (value.toLowerCase() !== 'true' && value.toLowerCase() !== 'false') {
         throw new Error(
-          `${systemVariable} contains invalid data. true/false expected.`
+          `true/false value expected for property {${propName}}, got {${value}}`
         );
       }
       // eslint-disable-next-line no-param-reassign
-      object[objectKey] = value.toLowerCase() === 'true';
+      object[propName] = value.toLowerCase() === 'true';
       break;
     case 'number':
       if (!Number(value)) {
         throw new Error(
-          `${systemVariable} contains invalid data. Number expected.`
+          `Number expected for property {${propName}}, got {${value}}`
         );
       }
       // eslint-disable-next-line no-param-reassign
-      object[objectKey] = Number(value);
+      object[propName] = Number(value);
       break;
     default:
       // eslint-disable-next-line no-param-reassign
-      object[objectKey] = value;
+      object[propName] = value;
   }
 }
 
 function overrideConfigValuesFromSystemVariables(
   configObj,
-  systemVariables = Object.keys(process.env)
+  systemVariables = process.env
 ) {
-  systemVariables.forEach(sysVar => {
+  Object.keys(systemVariables).forEach(sysVar => {
     let tokens = sysVar.toLowerCase().split('_');
+    let currentObj, currentProp;
+    let currentPropValue = configObj;
 
-    let currentObj = configObj;
-    let currentProp = tokens.shift();
-    while (tokens.length) {
-      const propValue = getPropertyCaseInsensitive(currentObj, currentProp);
-      if (propValue) {
-        currentObj = propValue;
-        currentProp = tokens.shift();
-      } else {
-        tokens = [];
-      }
-    }
+    do {
+      currentObj = currentPropValue;
+      currentProp = tokens.shift();
+      currentPropValue = getPropertyCaseInsensitive(currentObj, currentProp);
+    } while (tokens.length && isObject(currentPropValue));
+
     if (currentObj && currentProp && currentObj[currentProp]) {
-      setPropertyCaseInsensitive(currentObj, currentProp, sysVar);
+      setPropertyCaseInsensitive(
+        currentObj,
+        currentProp,
+        systemVariables[sysVar]
+      );
     }
   });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,69 @@
+function isObject(item) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+/**
+ * Check if the reference value is defined and has a value
+ * @param obj
+ * @returns {boolean|boolean}
+ */
+function hasValue(obj) {
+  return obj !== null && obj !== undefined;
+}
+
+/**
+ * Get the property from a object ignoring case.
+ * E.g.: obj.getProperty('HeLo') === obj.getProperty('hElO')
+ */
+function getPropertyCaseInsensitive(object, key) {
+  return object[
+    Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase())
+  ];
+}
+
+/**
+ * Set the value for an EXISTING property. It finds the property ignoring the case. If the following operations
+ * run in sequence the second will override the value of the first:
+ * obj.setProperty('HeLo', 'hi')
+ * obj.setProperty('hElO', 'hello')
+ *
+ * It also casts the new value to have the same data type. If cast fails the operation also fails
+ */
+function setPropertyCaseInsensitive(object, key, systemVariable) {
+  const objectKey = Object.keys(object).find(
+    k => k.toLowerCase() === key.toLowerCase()
+  );
+  const value = process.env[systemVariable];
+  // const castedValue = cast(object[objectKey], value);
+
+  switch (typeof object[objectKey]) {
+    case 'boolean':
+      if (value.toLowerCase() !== 'true' && value.toLowerCase() !== 'false') {
+        throw new Error(
+          `${systemVariable} contains invalid data. true/false expected.`
+        );
+      }
+      // eslint-disable-next-line no-param-reassign
+      object[objectKey] = value.toLowerCase() === 'true';
+      break;
+    case 'number':
+      if (!Number(value)) {
+        throw new Error(
+          `${systemVariable} contains invalid data. Number expected.`
+        );
+      }
+      // eslint-disable-next-line no-param-reassign
+      object[objectKey] = Number(value);
+      break;
+    default:
+      // eslint-disable-next-line no-param-reassign
+      object[objectKey] = value;
+  }
+}
+
+module.exports = {
+  isObject,
+  hasValue,
+  getPropertyCaseInsensitive,
+  setPropertyCaseInsensitive,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ function getPropertyCaseInsensitive(object, key) {
   if (objKeys.length > 1) {
     throw new Error(`Duplicated property found: ${key}`);
   }
-  return object[objKeys];
+  return isObject(object[objKeys[0]]) ? object[objKeys[0]] : undefined;
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,12 +21,10 @@ function getPropertyCaseInsensitive(object, property) {
 }
 
 /**
- * Set the value for an EXISTING property. It finds the property ignoring the case. If the following operations
- * run in sequence the second will override the value of the first:
- * obj.setProperty('HeLo', 'hi')
- * obj.setProperty('hElO', 'hello')
- *
- * It also casts the new value to have the same data type. If cast fails the operation also fails
+ * Set the value for an EXISTING property (case-insensitive). Throw error if:
+ * - Property does not exist in the object
+ * - System Variable value cannot be casted to the current property data type
+ * - If duplicated properties are found
  */
 function setPropertyCaseInsensitive(object, property, value) {
   const propName = getPropertyNameCaseInsensitive(object, property);

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "collectCoverageFrom": [
       "lib/**/*.js"
     ]
+  },
+  "resolutions": {
+    "lodash": "^4.17.19"
   }
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,29 +1,109 @@
-const { hasValue, getPropertyCaseInsensitive } = require('../lib/utils');
+const {
+  hasValue,
+  getPropertyCaseInsensitive,
+  overrideConfigValuesFromSystemVariables,
+} = require('../lib/utils');
 
-describe('test utils', () => {
-  it('hasValue', () => {
-    expect(hasValue({})).toBeTruthy();
-    expect(hasValue('')).toBeTruthy();
-    expect(hasValue([])).toBeTruthy();
-    expect(hasValue(0)).toBeTruthy();
-    expect(hasValue(undefined)).toBeFalsy();
-    expect(hasValue(null)).toBeFalsy();
+it('hasValue', () => {
+  expect(hasValue({})).toBeTruthy();
+  expect(hasValue('')).toBeTruthy();
+  expect(hasValue([])).toBeTruthy();
+  expect(hasValue(0)).toBeTruthy();
+  expect(hasValue(undefined)).toBeFalsy();
+  expect(hasValue(null)).toBeFalsy();
+});
+
+it('getPropertyCaseInsensitive', () => {
+  expect(getPropertyCaseInsensitive({}, 'hello')).toBeUndefined();
+  expect(getPropertyCaseInsensitive({ hello: 1 }, 'test')).toBeUndefined();
+  expect(
+    getPropertyCaseInsensitive({ hello: 1 }, 'HelloWorld')
+  ).toBeUndefined();
+  expect(getPropertyCaseInsensitive({ hello: 1 }, 'hell')).toBeUndefined();
+
+  expect(getPropertyCaseInsensitive({ test: 1 }, 'test')).toBe(1);
+  expect(getPropertyCaseInsensitive({ test: 1 }, 'TEST')).toBe(1);
+  expect(getPropertyCaseInsensitive({ test: 1 }, 'tEst')).toBe(1);
+
+  expect(() =>
+    getPropertyCaseInsensitive({ test: 1, Test: 2 }, 'test')
+  ).toThrowError(/test/);
+});
+
+describe('overrideConfigValuesFromSystemVariables', () => {
+  it('should read system variables by default', () => {
+    process.env.MY_TEST = 'test';
+    const config = { my: { test: 'mock' } };
+    overrideConfigValuesFromSystemVariables(config);
+    expect(config.my.test).toBe(process.env.MY_TEST);
   });
 
-  it('getPropertyCaseInsensitive', () => {
-    expect(getPropertyCaseInsensitive({}, 'hello')).toBeUndefined();
-    expect(getPropertyCaseInsensitive({ hello: 1 }, 'test')).toBeUndefined();
-    expect(
-      getPropertyCaseInsensitive({ hello: 1 }, 'HelloWorld')
-    ).toBeUndefined();
-    expect(getPropertyCaseInsensitive({ hello: 1 }, 'hell')).toBeUndefined();
+  it('should accept system varibale object map as optional parameter', () => {
+    const systemVariables = { MY_TEST: 'test' };
+    const config = { my: { test: 'mock' } };
+    overrideConfigValuesFromSystemVariables(config, systemVariables);
+    expect(config.my.test).toBe(systemVariables.MY_TEST);
+  });
 
-    expect(getPropertyCaseInsensitive({ test: 1 }, 'test')).toBe(1);
-    expect(getPropertyCaseInsensitive({ test: 1 }, 'TEST')).toBe(1);
-    expect(getPropertyCaseInsensitive({ test: 1 }, 'tEst')).toBe(1);
+  it('should override first level properties', () => {
+    const systemVariables = { SINGLE: 'single' };
+    const config = { single: 'mock' };
+    overrideConfigValuesFromSystemVariables(config, systemVariables);
+    expect(config.single).toBe(systemVariables.SINGLE);
+  });
 
-    expect(() =>
-      getPropertyCaseInsensitive({ test: 1, Test: 2 }, 'test')
-    ).toThrowError(/test/);
+  it('should override deep values', () => {
+    const systemVariables = {
+      COMPOSE_VAR: 'composeVar',
+      LONGER_TEST_VAR: 'longerTestVar',
+    };
+
+    const config = {
+      compose: { var: 'mock' },
+      longer: { test: { var: 'mock' } },
+    };
+
+    overrideConfigValuesFromSystemVariables(config, systemVariables);
+
+    expect(config.compose.var).toBe(systemVariables.COMPOSE_VAR);
+    expect(config.longer.test.var).toBe(systemVariables.LONGER_TEST_VAR);
+  });
+
+  it('should not override invalid system variable names', () => {
+    const systemVariables = {
+      TEST: 'test',
+      COM_POSE_VAR: 'composeVar',
+      LONGER_TESTVAR: 'longerTestVar',
+    };
+
+    const config = {
+      test: 'mock',
+      compose: { var: 'mock' },
+      longer: { test: { var: 'mock' } },
+    };
+
+    overrideConfigValuesFromSystemVariables(config, systemVariables);
+
+    expect(config.test).toBe('test');
+    expect(config.compose.var).toBe('mock');
+    expect(config.longer.test.var).toBe('mock');
+  });
+
+  it('should override kebap-case properties', () => {
+    const systemVariables = {
+      'SINGLE-TEST': 'single-test',
+      'TEST_SINGLE-TEST': 'testSingle-Test',
+    };
+    const config = {
+      'single-test': 'mock',
+      test: { 'single-test': 'single-test' },
+    };
+
+    overrideConfigValuesFromSystemVariables(config, systemVariables);
+
+    expect(config['single-test']).toBe(systemVariables['SINGLE-TEST']);
+    expect(config.test['single-test']).toBe(
+      systemVariables['TEST_SINGLE-TEST']
+    );
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,29 @@
+const { hasValue, getPropertyCaseInsensitive } = require('../lib/utils');
+
+describe('test utils', () => {
+  it('hasValue', () => {
+    expect(hasValue({})).toBeTruthy();
+    expect(hasValue('')).toBeTruthy();
+    expect(hasValue([])).toBeTruthy();
+    expect(hasValue(0)).toBeTruthy();
+    expect(hasValue(undefined)).toBeFalsy();
+    expect(hasValue(null)).toBeFalsy();
+  });
+
+  it('getPropertyCaseInsensitive', () => {
+    expect(getPropertyCaseInsensitive({}, 'hello')).toBeUndefined();
+    expect(getPropertyCaseInsensitive({ hello: 1 }, 'test')).toBeUndefined();
+    expect(
+      getPropertyCaseInsensitive({ hello: 1 }, 'HelloWorld')
+    ).toBeUndefined();
+    expect(getPropertyCaseInsensitive({ hello: 1 }, 'hell')).toBeUndefined();
+
+    expect(getPropertyCaseInsensitive({ test: 1 }, 'test')).toBe(1);
+    expect(getPropertyCaseInsensitive({ test: 1 }, 'TEST')).toBe(1);
+    expect(getPropertyCaseInsensitive({ test: 1 }, 'tEst')).toBe(1);
+
+    expect(() =>
+      getPropertyCaseInsensitive({ test: 1, Test: 2 }, 'test')
+    ).toThrowError(/test/);
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 const {
   hasValue,
   getPropertyCaseInsensitive,
+  setPropertyCaseInsensitive,
   overrideConfigValuesFromSystemVariables,
 } = require('../lib/utils');
 
@@ -28,6 +29,55 @@ it('getPropertyCaseInsensitive', () => {
   expect(() =>
     getPropertyCaseInsensitive({ test: 1, Test: 2 }, 'test')
   ).toThrowError(/test/);
+});
+
+describe('setPropertyCaseInsensitive', () => {
+  it('should fail if property does not exist', () => {
+    expect(() => setPropertyCaseInsensitive({}, 'test', 'test')).toThrowError(
+      /Error trying to set value {test} for non-existing property {test}/
+    );
+  });
+
+  it('should fail for duplicated properties', () => {
+    expect(() =>
+      setPropertyCaseInsensitive({ test: 'mock', Test: 'mock' }, 'test', 'test')
+    ).toThrowError(/Found duplicated {test} property/);
+  });
+
+  it('should fail if data types do not match', () => {
+    expect(() =>
+      setPropertyCaseInsensitive({ a: 1 }, 'a', 'true')
+    ).toThrowError(/Number expected for property {a}, got {true}/);
+    expect(() =>
+      setPropertyCaseInsensitive({ a: false }, 'a', '1')
+    ).toThrowError(/Value true\/false expected for property {a}, got {1}/);
+  });
+
+  it('should override numbers correctly', () => {
+    const obj = { a: 1 };
+    setPropertyCaseInsensitive(obj, 'a', '2');
+    expect(obj.a).toBe(2);
+    setPropertyCaseInsensitive(obj, 'a', '0');
+    expect(obj.a).toBe(0);
+    setPropertyCaseInsensitive(obj, 'a', '-1');
+    expect(obj.a).toBe(-1);
+    setPropertyCaseInsensitive(obj, 'a', '0.01');
+    expect(obj.a).toBe(0.01);
+    setPropertyCaseInsensitive(obj, 'a', '0.0');
+    expect(obj.a).toBe(0);
+    setPropertyCaseInsensitive(obj, 'a', '-0.1');
+    expect(obj.a).toBe(-0.1);
+    setPropertyCaseInsensitive(obj, 'a', '-0');
+    expect(obj.a).toBe(-0);
+  });
+
+  it('should override booleans correctly', () => {
+    const obj = { a: false };
+    setPropertyCaseInsensitive(obj, 'a', 'true');
+    expect(obj.a).toBeTruthy();
+    setPropertyCaseInsensitive(obj, 'a', 'false');
+    expect(obj.a).toBeFalsy();
+  });
 });
 
 describe('overrideConfigValuesFromSystemVariables', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,10 +2860,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Features:
- Check for duplicated properties in the configuration

Fixes:
- System variable resolution now behaves as expected: no unnecessary logic to match prefixes
- Add resolutions to bump lodash version used by dependencies. This fixes a [Prototype Pollution vulnerability](https://www.npmjs.com/advisories/1523)
- Fix resolution of number values from the system variables

Other:
- Update README to make property name constraints clear