### PR TITLE
fix: load/merge profiles in the correct priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ config["my-app-name"]
 
 Each configuration file in `auto-config-js` is called a profile configuration. Because of that, configuration files are named using the following convention:
 ```
-app-<PROFILE>.config.yaml
+app.<PROFILE>.config.yaml
 ```
 
 The `<PROFILE>` placeholder uses by default the `NODE_ENV` value. It can be overridden by passing the optional configuration parameter to the `autoConfig` function (check [API](#api)).
-
-If no profile specific file is found, `auto-config-js` will do a last attempt and try to load `app.config.yaml`.
 
 Profiles can be defined hierarchically using the `include` keyword. The include keyword expects an array of profiles names (strings) to be included. The configuration load each file and merge if the current configuration. Example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ YAML is a superset of JSON and, as such, is a convenient format for specifying h
 config["my-app-name"]
 ```
 
-⚠️ Although Javascript and YAML are case sensitive and accept properties with same name but different case in the same object (e.g. `variable`/`VARiable`, this lib will through an error in such cases. This constraint has the goal to improve the configuration readability and to make it possible the override of such properties by system variables.
+⚠️ Although Javascript and YAML are case sensitive and accept properties with same name but different case in the same object (e.g. `variable`/`VARiable`, this lib will throw an error in such cases. This constraint has the goal to improve the configuration readability and to make it possible the override of such properties by system variables.
 
 #### Name Convention
 

--- a/lib/autoConfig.js
+++ b/lib/autoConfig.js
@@ -1,79 +1,26 @@
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-
 const {
-  isObject,
+  loadConfiguration,
   overrideConfigValuesFromSystemVariables,
 } = require('./utils');
 
 // Global config
 let config;
 
-/**
- * Do a deep merge of two objects. This function will lead to infinite recursion on circular references
- * @param target
- * @param source
- */
-function mergeDeep(target, source) {
-  const output = { ...target };
-  if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (isObject(source[key])) {
-        if (!(key in target)) Object.assign(output, { [key]: source[key] });
-        else output[key] = mergeDeep(target[key], source[key]);
-      } else {
-        Object.assign(output, { [key]: source[key] });
-      }
-    });
-  }
-  return output;
-}
-
-/**
- * Load a configuration file recursively. The nested config overrides the previous.
- * This function will lead to infinite recursion on circular references
- * @param confObj
- */
-function loadConfig(confObj, filePath, configDirectory) {
-  let resultConfig = {};
-  if (confObj.include) {
-    if (Array.isArray(confObj))
-      throw new Error(`${filePath}: include field must be an array!`);
-
-    confObj.include.forEach(confName => {
-      const subPath = path.join(configDirectory, `app.${confName}.config.yaml`);
-      const includeConf = yaml.safeLoad(fs.readFileSync(subPath, 'utf8'));
-      resultConfig = mergeDeep(
-        resultConfig,
-        loadConfig(includeConf, subPath, configDirectory)
-      );
-    });
-  }
-  return mergeDeep(resultConfig, confObj);
-}
-
-function init({ profile = process.env.NODE_ENV, configDirectory = './' }) {
+function init({
+  profile = process.env.NODE_ENV,
+  configDirectory = process.cwd(),
+}) {
   if (!profile) throw new Error('NODE_ENV not set.');
 
   if (config) {
     console.warn(
-      'autoConfig.init was called again. Config will be re-initialized.'
+      'Config will be re-initialized: autoConfig.init was called again.'
     );
   }
 
-  try {
-    // Load config
-    const filePath = path.join(configDirectory, `app.${profile}.config.yaml`);
-
-    const confObj = yaml.safeLoad(fs.readFileSync(filePath, 'utf8'));
-    config = loadConfig(confObj, filePath, configDirectory);
-
-    overrideConfigValuesFromSystemVariables(config);
-    delete config.include;
-  } catch (e) {
-    throw new Error(`Auto configuration failed. ${e}`);
-  }
+  config = loadConfiguration(configDirectory, profile);
+  overrideConfigValuesFromSystemVariables(config);
+  delete config.include;
 }
 
 module.exports = { init, getConfig: () => config };

--- a/lib/autoConfig.js
+++ b/lib/autoConfig.js
@@ -17,7 +17,7 @@ function init({
 
   if (config) {
     console.warn(
-      'Config will be re-initialized: autoConfig.init was called again.'
+      'Config will be re-initialized: autoConfig.init was called again'
     );
   }
 

--- a/lib/autoConfig.js
+++ b/lib/autoConfig.js
@@ -9,8 +9,11 @@ let config;
 function init({
   profile = process.env.NODE_ENV,
   configDirectory = process.cwd(),
-}) {
-  if (!profile) throw new Error('NODE_ENV not set.');
+} = {}) {
+  if (!profile)
+    throw new Error(
+      'No profile was given: set NODE_ENV or pass it as a parameter'
+    );
 
   if (config) {
     console.warn(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
 function isObject(item) {
   return item && typeof item === 'object' && !Array.isArray(item);
 }
@@ -85,10 +89,63 @@ function overrideConfigValuesFromSystemVariables(
   });
 }
 
+// This function will lead to infinite recursion on circular references
+function mergeDeep(target, source) {
+  const output = { ...target };
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!(key in target)) Object.assign(output, { [key]: source[key] });
+        else output[key] = mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(output, { [key]: source[key] });
+      }
+    });
+  }
+  return output;
+}
+
+function loadYamlFile(configDirectory, profile) {
+  const filePath = path.join(configDirectory, `app.${profile}.config.yaml`);
+  return yaml.safeLoad(fs.readFileSync(filePath, 'utf8'));
+}
+
+// This function will lead to an infinite loop on circular references
+function loadConfiguration(configDirectory, profile) {
+  const queue = [];
+
+  const rootConfigObject = loadYamlFile(configDirectory, profile);
+
+  let resultConfig = {};
+  let currentConfig = rootConfigObject;
+  let currentProfile = profile;
+  do {
+    if (currentConfig.include) {
+      if (!Array.isArray(currentConfig.include)) {
+        throw new Error(
+          `Include field must be an array in profile: ${profile}!`
+        );
+      }
+      currentConfig.include.forEach(p => queue.unshift(p));
+    }
+
+    currentProfile = queue.shift();
+    if (currentProfile) {
+      currentConfig = loadYamlFile(configDirectory, currentProfile);
+      resultConfig = mergeDeep(resultConfig, currentConfig);
+    }
+  } while (queue.length);
+
+  return mergeDeep(resultConfig, rootConfigObject);
+}
+
 module.exports = {
   isObject,
   hasValue,
   getPropertyCaseInsensitive,
   setPropertyCaseInsensitive,
   overrideConfigValuesFromSystemVariables,
+  mergeDeep,
+  loadYamlFile,
+  loadConfiguration,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -112,31 +112,24 @@ function loadYamlFile(configDirectory, profile) {
 
 // This function will lead to an infinite loop on circular references
 function loadConfiguration(configDirectory, profile) {
-  const queue = [];
+  const toLoadStack = [profile];
+  const toProcessStack = [];
 
-  const rootConfigObject = loadYamlFile(configDirectory, profile);
+  while (toLoadStack.length) {
+    const currentProfile = toLoadStack.shift();
+    const currentConfig = loadYamlFile(configDirectory, currentProfile);
+    toProcessStack.unshift(currentConfig);
 
-  let resultConfig = {};
-  let currentConfig = rootConfigObject;
-  let currentProfile = profile;
-  do {
     if (currentConfig.include) {
       if (!Array.isArray(currentConfig.include)) {
         throw new Error(
           `Include field must be an array in profile: ${profile}!`
         );
       }
-      currentConfig.include.forEach(p => queue.unshift(p));
+      toLoadStack.unshift(...currentConfig.include.reverse());
     }
-
-    currentProfile = queue.shift();
-    if (currentProfile) {
-      currentConfig = loadYamlFile(configDirectory, currentProfile);
-      resultConfig = mergeDeep(resultConfig, currentConfig);
-    }
-  } while (queue.length);
-
-  return mergeDeep(resultConfig, rootConfigObject);
+  }
+  return toProcessStack.reduce((acc, current) => mergeDeep(acc, current));
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,15 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "lib/**/*.js"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": -15
+      }
+    }
   },
   "resolutions": {
     "lodash": "^4.17.19"

--- a/test/autoConfig.test.js
+++ b/test/autoConfig.test.js
@@ -1,5 +1,11 @@
-describe('Test autoConfig', () => {
-  it('dummy test to setup jest', () => {
-    expect(true).toBeTruthy();
+const autoConfig = require('../lib/autoConfig');
+
+describe('test init', () => {
+  it('should throw error if profile is not defined', () => {
+    delete process.env.NODE_ENV;
+    expect(() => autoConfig.init()).toThrowError(
+      /No profile was given: set NODE_ENV or pass it as a parameter/
+    );
+    process.env.NODE_ENV = 'test';
   });
 });

--- a/test/autoConfig.test.js
+++ b/test/autoConfig.test.js
@@ -1,11 +1,71 @@
-const autoConfig = require('../lib/autoConfig');
+const utils = require('../lib/utils');
 
-describe('test init', () => {
+jest.mock('../lib/utils', () => ({
+  loadConfiguration: jest.fn(() => ({
+    include: [],
+  })),
+  overrideConfigValuesFromSystemVariables: jest.fn(),
+}));
+
+describe('test autoConfig', () => {
+  let autoConfig;
+
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      autoConfig = require('../lib/autoConfig');
+    });
+  });
+
   it('should throw error if profile is not defined', () => {
     delete process.env.NODE_ENV;
     expect(() => autoConfig.init()).toThrowError(
       /No profile was given: set NODE_ENV or pass it as a parameter/
     );
     process.env.NODE_ENV = 'test';
+  });
+
+  it('should warn if init is called more than once', () => {
+    const spy = jest.spyOn(console, 'warn');
+    spy.mockImplementation(() => {});
+
+    autoConfig.init();
+    autoConfig.init();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Config will be re-initialized: autoConfig.init was called again'
+    );
+    spy.mockRestore();
+  });
+
+  it('should not contain keyword include in the config object', () => {
+    autoConfig.init();
+    expect(autoConfig.getConfig().include).toBeUndefined();
+  });
+
+  it('should configure profile using optional object parameter', () => {
+    autoConfig.init({ profile: 'mockProfile' });
+    expect(utils.loadConfiguration).toHaveBeenCalledWith(
+      expect.anything(),
+      'mockProfile'
+    );
+  });
+
+  it('should configure config directory using option object parameter', () => {
+    autoConfig.init({ profile: 'mockProfile', configDirectory: '/mock/test' });
+    expect(utils.loadConfiguration).toHaveBeenCalledWith(
+      '/mock/test',
+      'mockProfile'
+    );
+  });
+
+  it('should be able to get the configuration files', () => {
+    const mockConfig = {
+      test: 1,
+      mock: 'mock',
+    };
+    utils.loadConfiguration.mockImplementationOnce(() => mockConfig);
+    expect(autoConfig.getConfig()).toBeUndefined();
+    autoConfig.init();
+    expect(autoConfig.getConfig()).toEqual(mockConfig);
   });
 });

--- a/test/autoConfig.test.js
+++ b/test/autoConfig.test.js
@@ -37,7 +37,7 @@ describe('test autoConfig', () => {
     spy.mockRestore();
   });
 
-  it('should not contain keyword include in the config object', () => {
+  it('should not contain keyword [include] in the config object', () => {
     autoConfig.init();
     expect(autoConfig.getConfig().include).toBeUndefined();
   });
@@ -67,5 +67,13 @@ describe('test autoConfig', () => {
     expect(autoConfig.getConfig()).toBeUndefined();
     autoConfig.init();
     expect(autoConfig.getConfig()).toEqual(mockConfig);
+  });
+
+  it('should work with default params', () => {
+    autoConfig.init();
+    expect(utils.loadConfiguration).toHaveBeenCalledWith(
+      process.cwd(),
+      process.env.NODE_ENV
+    );
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,9 +1,17 @@
+jest.mock('fs');
+jest.mock('path');
+jest.mock('js-yaml');
+
+const path = require('path');
+const yaml = require('js-yaml');
+
 const {
   hasValue,
   getPropertyCaseInsensitive,
   setPropertyCaseInsensitive,
   overrideConfigValuesFromSystemVariables,
   mergeDeep,
+  loadConfiguration,
 } = require('../lib/utils');
 
 it('hasValue', () => {
@@ -183,5 +191,147 @@ describe('mergeDeep', () => {
       a: 1,
       b: { c: 'cTest', d: { e: 'eTest', f: 'f' } },
     });
+  });
+});
+
+describe('loadConfiguration', () => {
+  it('should fail if include tag is invalid', () => {
+    yaml.safeLoad = jest.fn(() => ({ include: 1 }));
+    expect(() => loadConfiguration('mockPath', 'mockProfile')).toThrowError(
+      /Include field must be an array in profile: mockProfile!/
+    );
+
+    yaml.safeLoad = jest.fn(() => ({ include: 'test' }));
+    expect(() => loadConfiguration('mockPath', 'mockProfile')).toThrowError(
+      /Include field must be an array in profile: mockProfile!/
+    );
+
+    yaml.safeLoad = jest.fn(() => ({ include: {} }));
+    expect(() => loadConfiguration('mockPath', 'mockProfile')).toThrowError(
+      /Include field must be an array in profile: mockProfile!/
+    );
+  });
+
+  it('should load config with no includes', () => {
+    yaml.safeLoad = jest.fn(() => ({ myApp: 'mock' }));
+    expect(loadConfiguration('mockPath', 'mockProfile')).toEqual({
+      myApp: 'mock',
+    });
+  });
+
+  it('should load config with single include', () => {
+    yaml.safeLoad = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        myApp: 'mock',
+        include: ['subProfile'],
+      }))
+      .mockImplementationOnce(() => ({ test: 1 }));
+
+    expect(loadConfiguration('mockPath', 'mockProfile')).toEqual({
+      myApp: 'mock',
+      test: 1,
+      include: ['subProfile'],
+    });
+  });
+
+  it('should load config with multiple includes', () => {
+    yaml.safeLoad = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        myApp: 'mock',
+        include: ['subProfile', 'subProfile2'],
+      }))
+      .mockImplementationOnce(() => ({ test: 1 }))
+      .mockImplementationOnce(() => ({ mock: 2 }));
+
+    expect(loadConfiguration('mockPath', 'mockProfile')).toEqual({
+      myApp: 'mock',
+      test: 1,
+      mock: 2,
+      include: ['subProfile', 'subProfile2'],
+    });
+  });
+
+  it('should load config with nested includes', () => {
+    yaml.safeLoad = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        myApp: 'mock',
+        include: ['subProfile'],
+      }))
+      .mockImplementationOnce(() => ({ test: 1, include: ['subProfile2'] }))
+      .mockImplementationOnce(() => ({ mock: 2 }));
+
+    expect(loadConfiguration('mockPath', 'mockProfile')).toEqual({
+      myApp: 'mock',
+      test: 1,
+      mock: 2,
+      include: ['subProfile'],
+    });
+  });
+
+  it('should load respect merge priority', () => {
+    yaml.safeLoad = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        myApp: 'root',
+        include: ['subProfile', 'subProfile3'],
+      }))
+      .mockImplementationOnce(() => ({
+        myApp: 'subProfile3',
+        test: 'subProfile3',
+        include: ['subProfile4', 'subProfile5'],
+      }))
+      .mockImplementationOnce(() => ({
+        myApp: 'subProfile5',
+      }))
+      .mockImplementationOnce(() => ({
+        myApp: 'subProfile4',
+      }))
+      .mockImplementationOnce(() => ({
+        myApp: 'subProfile',
+        test: 'test',
+        include: ['subProfile2'],
+      }))
+      .mockImplementationOnce(() => ({ myApp: 'subProfile2' }));
+
+    const mockPath = 'mockPath';
+    expect(loadConfiguration(mockPath, 'mockProfile')).toEqual({
+      myApp: 'root',
+      test: 'subProfile3',
+      include: expect.anything(),
+    });
+
+    expect(path.join).toHaveBeenNthCalledWith(
+      1,
+      mockPath,
+      'app.mockProfile.config.yaml'
+    );
+    expect(path.join).toHaveBeenNthCalledWith(
+      2,
+      mockPath,
+      'app.subProfile3.config.yaml'
+    );
+    expect(path.join).toHaveBeenNthCalledWith(
+      3,
+      mockPath,
+      'app.subProfile5.config.yaml'
+    );
+    expect(path.join).toHaveBeenNthCalledWith(
+      4,
+      mockPath,
+      'app.subProfile4.config.yaml'
+    );
+    expect(path.join).toHaveBeenNthCalledWith(
+      5,
+      mockPath,
+      'app.subProfile.config.yaml'
+    );
+    expect(path.join).toHaveBeenNthCalledWith(
+      6,
+      mockPath,
+      'app.subProfile2.config.yaml'
+    );
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -172,7 +172,7 @@ describe('mergeDeep', () => {
     expect(mergeDeep({}, {})).toEqual({});
   });
 
-  it('should create non existing properties in the targe object', () => {
+  it('should create non existing properties in the target object', () => {
     expect(mergeDeep({}, { test: 1 })).toEqual({ test: 1 });
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -249,7 +249,7 @@ describe('loadConfiguration', () => {
       myApp: 'mock',
       test: 1,
       mock: 2,
-      include: ['subProfile', 'subProfile2'],
+      include: expect.anything(),
     });
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,6 +3,7 @@ const {
   getPropertyCaseInsensitive,
   setPropertyCaseInsensitive,
   overrideConfigValuesFromSystemVariables,
+  mergeDeep,
 } = require('../lib/utils');
 
 it('hasValue', () => {
@@ -155,5 +156,32 @@ describe('overrideConfigValuesFromSystemVariables', () => {
     expect(config.test['single-test']).toBe(
       systemVariables['TEST_SINGLE-TEST']
     );
+  });
+});
+
+describe('mergeDeep', () => {
+  it('should merge empty objects', () => {
+    expect(mergeDeep({}, {})).toEqual({});
+  });
+
+  it('should create non existing properties in the targe object', () => {
+    expect(mergeDeep({}, { test: 1 })).toEqual({ test: 1 });
+  });
+
+  it('should not remove any existing properties from target object', () => {
+    expect(mergeDeep({ test: 1 }, {})).toEqual({ test: 1 });
+  });
+
+  it('should override target property', () => {
+    expect(mergeDeep({ test: 1 }, { test: 'test' })).toEqual({ test: 'test' });
+  });
+
+  it('should override nested objects correctly', () => {
+    const target = { a: 1, b: { c: 'c', d: { e: 'e', f: 'f' } } };
+    const source = { b: { c: 'cTest', d: { e: 'eTest' } } };
+    expect(mergeDeep(target, source)).toEqual({
+      a: 1,
+      b: { c: 'cTest', d: { e: 'eTest', f: 'f' } },
+    });
   });
 });


### PR DESCRIPTION
Fixes:
- Now the init function works correctly with the default parameters
- Load and merge of profiles now respects the priority order

Other:
- Make load configuration non-recursive and organize modules
- Add tests and requires at least 90% coverage to deploy
- Update README to remove references to a fallback file that (never implemented)