### PR TITLE
ci: add OIDC publishing, split lint and build jobs, test on all LTS nodes

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,17 +1,28 @@
-name: auto-config-js tests
+name: auto-config-js npm-publish
 on:
   push:
     branches:
       - main
   pull_request:
 jobs:
-  test:
-    name: 'test: node ${{ matrix.node }} ${{ matrix.os }} '
-    runs-on: '${{ matrix.os }}'
+  lint:
+    name: 'lint and typecheck'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+  build:
+    name: 'build and test: node ${{ matrix.node }}'
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node: [22]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,18 +30,22 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - run: npm run typecheck
-      - run: npm run lint
       - run: npm test
+      - run: npm run build
   publish:
     name: 'Publish Module to NPM'
-    needs: test
+    needs: [lint, build]
     # publish only when merged in main on original repo, not on PR
     if: github.repository_owner == 'otaciliolacerda' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
@@ -44,5 +59,5 @@ jobs:
       - name: Publish
         run: npx semantic-release@latest
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{secrets.GH_TOKEN}}


### PR DESCRIPTION
- Replace `NPM_TOKEN` secret with OIDC provenance publishing (`NPM_CONFIG_PROVENANCE: true`) — no long-lived npm token stored in GitHub secrets
- Add `id-token: write` and `contents: write` permissions to the publish job
- Add `environment: production` to the publish job so npm OIDC can scope publishing to a specific GitHub environment
- Split `lint`/`typecheck` into a dedicated job that runs once, separate from the build matrix
- Expand build matrix to cover all Node LTS versions from 22 onwards (`[22, 24]`)
- `publish` now requires both `lint` and `build` to pass before running
- Add `fetch-depth: 0` to publish checkout so semantic-release can read full git history
- Move `build` step into the test job so broken builds are caught on PRs