### PR TITLE
feat: add CJS dual-package build via dist/cjs/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,20 @@
   "version": "0.0.0",
   "description": "Hierarchical NodeJS configuration with Yaml files, environment variables and config merging.",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
   "files": [
     "dist"
   ],
@@ -39,7 +51,7 @@
     "js-yaml": "^4.1.1"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'},null,2))\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint --fix",

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "outDir": "./dist/cjs",
+    "rootDir": "./lib",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["lib/**/*"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./lib"
+    "rootDir": "./lib",
+    "outDir": "./dist/esm"
   },
   "include": ["lib/**/*"]
 }


### PR DESCRIPTION
## Add CJS dual-package build

Consumers using `moduleResolution: node16` or compiling to CJS could not import the package because it only shipped an ESM build.

## Changes

- Add `tsconfig.build.cjs.json` targeting `module: commonjs` → `dist/cjs/`
- Update `tsconfig.build.json` to output ESM to `dist/esm/` (previously `dist/`)
- Write `dist/cjs/package.json` (`{"type":"commonjs"}`) as a post-build step so Node treats that directory as CJS without needing `.cjs` file extensions
- Add `exports` field with `import`/`require` conditions, each with their own `types` pointer
- Update `main` and `types` to point at the new paths

## How it works

Node resolves module type using the nearest `package.json`. Dropping `{"type":"commonjs"}` into `dist/cjs/` is enough — no file renaming or `.cjs` extensions needed. ESM consumers get `dist/esm/index.js`, CJS consumers get `dist/cjs/index.js`.